### PR TITLE
改善対応：応答速度を向上するため、1フレーズ目のテキストと同時にTTS呼び出しを行う

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -250,6 +250,8 @@ audio.onended イベントの後に次のフレーズが再生される点はA�
         conversationHistory.push({ role: 'user', content: message });
       } else if (sender === 'ai') {
         conversationHistory.push({ role: 'assistant', content: message });
+        // ★ ここでTTSを呼び出す(最小限変更) ★
+        sendTTSRequest(message);
       }
 
       // チャット履歴をローカルストレージに保存
@@ -293,20 +295,16 @@ audio.onended イベントの後に次のフレーズが再生される点はA�
                 const content = data.content;
                 if (content === "【END】") {
                   // 送信が終了したことを示す
-                  if (accumulatedPartialText.trim() !== '') {
-                    // enqueueTTSRequest(accumulatedPartialText.trim());
-                    // ★変更前★
-                    // await sendTTSRequest(accumulatedPartialText.trim());
-                    // → テキスト表示後に「待って」TTS呼び出ししていた
-
-                    // ★変更後★: 非同期で呼び出し (並行実行)
-                    sendTTSRequest(accumulatedPartialText.trim()); 
+                  if (accumulatedPartialText.trim() !== '') {                    
+                    // enqueueTTSRequest(accumulatedPartialText.trim()); // 音声キューに追加
+                    // await sendTTSRequest(accumulatedPartialText.trim()); // テキスト表示後に「待って」TTS呼び出ししていた
+                    // sendTTSRequest(accumulatedPartialText.trim()); // 非同期で呼び出し (並行実行)
                     accumulatedPartialText = '';
                   }
                   continue;
                 }
 
-                // Append to accumulatedPartialText
+                // 従来: while文で文末判定し addMessage, sendTTSRequest していたが削除
                 accumulatedPartialText += content;
 
                 // Check for sentence boundary (。、！、？)
@@ -315,13 +313,10 @@ audio.onended イベントの後に次のフレーズが再生される点はA�
                   const sentence = accumulatedPartialText.slice(0, sentenceEndIndex + 1);
                   accumulatedPartialText = accumulatedPartialText.slice(sentenceEndIndex + 1);
                   addMessage(sentence, 'ai'); // AIのメッセージをチャットに追加
+                  
                   // enqueueTTSRequest(sentence); // 完全な文をTTSに送信
-                  // ★変更前★
-                  // await sendTTSRequest(sentence);
-                  // → テキスト表示を待ってから音声を呼び出し、結果的に遅れる
-
-                  // ★変更後★
-                  sendTTSRequest(sentence); // 並列呼び出し
+                  // await sendTTSRequest(sentence); //テキスト表示を待ってから音声を呼び出し、結果的に遅れる
+                  // sendTTSRequest(sentence); // 並列呼び出し
                 }
 
               } catch (e) {


### PR DESCRIPTION
改善対応：応答速度を向上するため、1フレーズ目のテキストと同時にTTS呼び出しを行う
画面に “AI: message” を表示した直後＝同じタイミングで TTS を呼び出

解説

1. sendChatAndStreamResponse では 文字列を受け取るのみ で、TTS 呼び出しは行わないように変更（あるいは削除）。
2. addMessage(message, 'ai') の中で sendTTSRequest(message) を呼ぶ
- これにより、画面表示と音声呼び出しが同じタイミングになる。
  - 旧:
    - addMessage(sentence, 'ai');
    - sendTTSRequest(sentence);
のように “別行” だったロジックを、“同じ関数” にまとめるイメージです。
3. ストリーミングの文末判定をどうするか
- 上記サンプルでは「最小限の変更」を目的にしているため、accumulatedPartialText への文字列追記後にいつ addMessage(...) を呼ぶかはお任せしています。
- 実際には文末（。や！？）が来たタイミングや**【END】**が来たタイミングで addMessage を呼ぶケースが多いです。